### PR TITLE
Fix CSS Dev Bug, Add 404 Page

### DIFF
--- a/src/client/components/NotFound.js
+++ b/src/client/components/NotFound.js
@@ -1,0 +1,15 @@
+/* @flow */
+import React, { Component } from 'react';
+import styles from './NotFound.scss';
+
+// Note: Top level components must be class based for HMR to function
+// eslint-disable-next-line react/prefer-stateless-function
+export default class NotFound extends Component {
+  render() {
+    return (
+      <div className={styles['not-found']}>
+        <h1>404 - Page Not Found</h1>
+      </div>
+    );
+  }
+}

--- a/src/client/components/NotFound.scss
+++ b/src/client/components/NotFound.scss
@@ -1,0 +1,3 @@
+.not-found {
+  padding: 0 1rem;
+}

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -2,6 +2,7 @@
 import App from './components/App';
 import Home from './components/Home';
 import Detail from './components/Detail';
+import NotFound from './components/NotFound';
 
 const routes = {
   path: '',
@@ -14,6 +15,10 @@ const routes = {
     {
       path: '/detail/:id',
       component: Detail,
+    },
+    {
+      path: '*',
+      component: NotFound,
     },
   ],
 };

--- a/src/server/util/__tests__/routeMatch.prod.test.js
+++ b/src/server/util/__tests__/routeMatch.prod.test.js
@@ -73,6 +73,7 @@ describe('routeMatchCallback', () => {
       expect(mockResponse.render).toBeCalledWith('index', {
         buildPath: '/build',
         html: mockHtml,
+        isProd: true,
       });
     });
 

--- a/src/server/util/__tests__/routeMatch.test.js
+++ b/src/server/util/__tests__/routeMatch.test.js
@@ -25,6 +25,7 @@ describe('routeMatch', () => {
     expect(responseMock.render).toBeCalledWith('index', {
       html: '',
       buildPath: null,
+      isProd: false,
     });
   });
 });

--- a/src/server/util/routeMatch.js
+++ b/src/server/util/routeMatch.js
@@ -11,6 +11,16 @@ import { CSS_MODULE_PATTERN } from '../../../webpack/config';
 
 const distConfig = configFactory('dist');
 
+function renderPage(response: express$Response) {
+  return (html: string, buildPath: ?string, isProd: boolean) => {
+    response.render('index', {
+      html,
+      buildPath,
+      isProd,
+    });
+  };
+}
+
 export function getBuildPath(isprodEnv: boolean, webpackConfig: Namespace$WebpackConfig) {
   if (isprodEnv) {
     // remove trailing slash
@@ -38,11 +48,7 @@ export function routeMatchCallback(response: express$Response): Function {
       );
 
       const buildPath = getBuildPath(isprod, distConfig);
-
-      response.render('index', {
-        html,
-        buildPath,
-      });
+      renderPage(response)(html, buildPath, isprod);
       return;
     }
 
@@ -72,9 +78,5 @@ export default function routeMatch(request: express$Request, response: express$R
   }
 
   const buildPath = getBuildPath(isprod, distConfig);
-
-  response.render('index', {
-    html: '',
-    buildPath,
-  });
+  renderPage(response)('', buildPath, isprod);
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -6,7 +6,9 @@
   <title>Express Starter</title>
   <meta name="description" content="FIXME">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="<%-buildPath%>/bundle.css" />
+  <%if (isProd) { %>
+    <link rel="stylesheet" href="<%-buildPath%>/bundle.css" />
+  <% } %>
 </head>
 <body>
   <!--[if lt IE 9]>


### PR DESCRIPTION
* Only load the CSS bundle if its in prod mode. Otherwise CSS is injected via webpack in `style` tags
* Add React `NotFound` component to act as 404 page