### PR TITLE
Split hot and webpack into separate middleware

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
         'src/server/middleware/hot.js',
         'src/server/middleware/webpackDev.js',
         'src/server/util/routeMatch.js',
+        'src/server/util/webpackDevBundler.js',
       ],
     }],
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
         '**/*.test.js',
         'src/www/dev.js',
         'src/server/middleware/hot.js',
+        'src/server/middleware/webpackDev.js',
         'src/server/util/routeMatch.js',
       ],
     }],

--- a/src/server/__tests__/app.prod.test.js
+++ b/src/server/__tests__/app.prod.test.js
@@ -1,6 +1,7 @@
 import app from '../app';
 
 jest.mock('../middleware/hot', () => jest.fn());
+jest.mock('../middleware/webpackDev', () => ({ default: jest.fn() }));
 jest.mock('../util/isprod', () => true);
 
 it('should be defined when running in a development environment', () => {

--- a/src/server/__tests__/app.test.js
+++ b/src/server/__tests__/app.test.js
@@ -1,6 +1,7 @@
 import app from '../app';
 
 jest.mock('../middleware/hot', () => ({ default: jest.fn() }));
+jest.mock('../middleware/webpackDev', () => ({ default: jest.fn() }));
 
 it('should be defined', () => {
   expect(app).toBeDefined();

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -16,7 +16,9 @@ app.use(express.static('public'));
 app.set('view engine', 'ejs');
 
 if (!isprod) {
+  const webpackDevMiddleware = require('./middleware/webpackDev'); // eslint-disable-line global-require
   const hotMiddleware = require('./middleware/hot'); // eslint-disable-line global-require
+  app.use(webpackDevMiddleware.default);
   app.use(hotMiddleware.default);
 }
 

--- a/src/server/middleware/__tests__/hot.test.js
+++ b/src/server/middleware/__tests__/hot.test.js
@@ -1,15 +1,8 @@
-import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
-import hot from '../hot';
+import '../hot';
 
-jest.mock('webpack-dev-middleware');
-jest.mock('webpack-hot-middleware');
+jest.mock('webpack-hot-middleware', () => jest.fn());
 
-webpackDevMiddleware.mockImplementation(() => () => 'dev');
-webpackHotMiddleware.mockImplementation(() => () => 'hot');
-
-it('should create a a list of hot middleware', () => {
-  expect(webpackDevMiddleware).toBeCalled();
+it('should call middleware', () => {
   expect(webpackHotMiddleware).toBeCalled();
-  expect(hot.length).toBe(2);
 });

--- a/src/server/middleware/__tests__/webpackDev.test.js
+++ b/src/server/middleware/__tests__/webpackDev.test.js
@@ -1,0 +1,8 @@
+import webpackDevMiddleware from 'webpack-dev-middleware';
+import '../webpackDev';
+
+jest.mock('webpack-dev-middleware', () => jest.fn());
+
+it('should call middleware', () => {
+  expect(webpackDevMiddleware).toBeCalled();
+});

--- a/src/server/middleware/hot.js
+++ b/src/server/middleware/hot.js
@@ -1,5 +1,4 @@
 /* @flow */
-import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 import webpack from 'webpack';
 import configFactory from '../../../webpack.config';
@@ -7,18 +6,8 @@ import configFactory from '../../../webpack.config';
 const config = configFactory('dev');
 const bundler = webpack(config);
 
-const middleware = [
-  webpackDevMiddleware(bundler, {
-    filename: config.output.filename,
-    publicPath: config.output.publicPath,
-    hot: true,
-    stats: {
-      colors: true,
-    },
-  }),
-  webpackHotMiddleware(bundler, {
-    log: console.log, // eslint-disable-line no-console
-  }),
-];
+const middleware = webpackHotMiddleware(bundler, {
+  log: console.log, // eslint-disable-line no-console
+});
 
 export default middleware;

--- a/src/server/middleware/hot.js
+++ b/src/server/middleware/hot.js
@@ -1,10 +1,8 @@
 /* @flow */
 import webpackHotMiddleware from 'webpack-hot-middleware';
-import webpack from 'webpack';
-import configFactory from '../../../webpack.config';
+import webpackDevBundler from '../util/webpackDevBundler';
 
-const config = configFactory('dev');
-const bundler = webpack(config);
+const { bundler } = webpackDevBundler();
 
 const middleware = webpackHotMiddleware(bundler, {
   log: console.log, // eslint-disable-line no-console

--- a/src/server/middleware/webpackDev.js
+++ b/src/server/middleware/webpackDev.js
@@ -1,10 +1,8 @@
 /* @flow */
 import webpackDevMiddleware from 'webpack-dev-middleware';
-import webpack from 'webpack';
-import configFactory from '../../../webpack.config';
+import webpackDevBundler from '../util/webpackDevBundler';
 
-const config = configFactory('dev');
-const bundler = webpack(config);
+const { config, bundler } = webpackDevBundler();
 
 const middleware = webpackDevMiddleware(bundler, {
   filename: config.output.filename,

--- a/src/server/middleware/webpackDev.js
+++ b/src/server/middleware/webpackDev.js
@@ -1,0 +1,18 @@
+/* @flow */
+import webpackDevMiddleware from 'webpack-dev-middleware';
+import webpack from 'webpack';
+import configFactory from '../../../webpack.config';
+
+const config = configFactory('dev');
+const bundler = webpack(config);
+
+const middleware = webpackDevMiddleware(bundler, {
+  filename: config.output.filename,
+  publicPath: config.output.publicPath,
+  hot: true,
+  stats: {
+    colors: true,
+  },
+});
+
+export default middleware;

--- a/src/server/util/__tests__/webpackDevBundler.test.js
+++ b/src/server/util/__tests__/webpackDevBundler.test.js
@@ -1,0 +1,16 @@
+import createWebpackBundler from '../webpackDevBundler';
+
+it('should create a config and bundler', () => {
+  const { config, bundler } = createWebpackBundler();
+
+  expect(config).toBeDefined();
+  expect(bundler).toBeDefined();
+});
+
+it('should be treated as a singleton', () => {
+  const { config, bundler } = createWebpackBundler();
+  const { config: config2, bundler: bundler2 } = createWebpackBundler();
+
+  expect(config).toBe(config2);
+  expect(bundler).toBe(bundler2);
+});

--- a/src/server/util/webpackDevBundler.js
+++ b/src/server/util/webpackDevBundler.js
@@ -1,0 +1,18 @@
+/* @flow */
+import webpack from 'webpack';
+import configFactory from '../../../webpack.config';
+
+let config;
+let bundler;
+
+export default function createWebpackBundler() {
+  if (!config) {
+    config = configFactory('dev');
+    bundler = webpack(config);
+  }
+
+  return {
+    config,
+    bundler,
+  };
+}


### PR DESCRIPTION
* Separate webpack dev middleware from hot middleware
* Create a singleton to share configurations across the two
* Simplify tests for webpack dev and hot middlewares